### PR TITLE
Update config.toml build_search_index = false

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@ compile_sass = true
 title = "Feng"
 description = "A clean resume theme"
 generate_feed = true
-build_search_index = true
+build_search_index = false
 taxonomies = [
   { name = "tags", feed = true },
 ]


### PR DESCRIPTION
Since the theme does not include any Search features, may as well not build the search index, the site/theme will compile slightly faster too, will also save the bandwidth on loading the javascript library and index for elasticlunr.